### PR TITLE
log size of ssl ca and peer certificates

### DIFF
--- a/apps/aura/src/aura.app.src
+++ b/apps/aura/src/aura.app.src
@@ -16,7 +16,7 @@
 {application, aura,
    [
       {description, "telemetry i/o and storage layer"},
-      {vsn,         "0.1.0"},
+      {vsn,         "0.1.1"},
       {modules,     []},
       {registered,  []},
       {applications,[

--- a/apps/aura/src/aura_protocol.erl
+++ b/apps/aura/src/aura_protocol.erl
@@ -47,7 +47,7 @@ encode({urn, _, _} = Urn, T, {ssl, ca, X}) ->
 
 encode({urn, _, _} = Urn, T, {ssl, peer, X}) ->
    % size of peer certificate
-   encode(uri:schema(<<"ca">>, Urn), T, X);
+   encode(uri:schema(<<"peer">>, Urn), T, X);
 
 encode({urn, _, _} = Urn, T, {http, ttfb, X}) ->
    encode(uri:schema(<<"ttfb">>, Urn), T, X);

--- a/apps/aura/src/aura_protocol.erl
+++ b/apps/aura/src/aura_protocol.erl
@@ -41,6 +41,14 @@ encode({urn, _, _} = Urn, T, {ssl, handshake, X}) ->
 encode({urn, _, _} = Urn, T, {ssl, packet, X}) ->
    encode(uri:schema(<<"pack">>, Urn),  T, X);
 
+encode({urn, _, _} = Urn, T, {ssl, ca, X}) ->
+   % size of certificate authority
+   encode(uri:schema(<<"ca">>, Urn), T, X);
+
+encode({urn, _, _} = Urn, T, {ssl, peer, X}) ->
+   % size of peer certificate
+   encode(uri:schema(<<"ca">>, Urn), T, X);
+
 encode({urn, _, _} = Urn, T, {http, ttfb, X}) ->
    encode(uri:schema(<<"ttfb">>, Urn), T, X);
 


### PR DESCRIPTION
the analysis on certificate sizes allows to estimate number of
round-trips required for ssl handshake